### PR TITLE
make plugin craft 4 ready

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "docs": "https://github.com/ostark/craft-plugin-commands"
   },
   "require": {
-    "craftcms/cms": "^3.0.0"
+    "craftcms/cms": "^3.2.0 || ^4.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Commands.php
+++ b/src/Commands.php
@@ -175,7 +175,7 @@ class Commands extends BaseConsoleController
         }
 
         foreach ($filters as $key => $value) {
-            $plugins = ArrayHelper::filterByValue($plugins, $key, $value);
+            $plugins = ArrayHelper::where($plugins, $key, $value);
         }
 
         return array_keys($plugins);


### PR DESCRIPTION
With a little improvement, the plugin is Craft 4 ready. The minimum version should be raised to 3.2.0, because the used function is only available until this version.